### PR TITLE
Hello PHP: PHP終了タグの削除

### DIFF
--- a/hellos/hello.php
+++ b/hellos/hello.php
@@ -3,4 +3,3 @@
 print("Hello, Wandbox!\n");
 //  PHP references:
 //  http://php.net
-?>


### PR DESCRIPTION
現在の標準的なコーディング規則によると、
(HTMLテンプレートとしてではない)PHPファイルでは `?>` を省略することになっていますので
当該コードを削除します。

Refs: http://www.infiniteloop.co.jp/docs/psr/psr-2-coding-style-guide.html §2.2