### PR TITLE
Fix engines version

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "publisher": "wraith13",
     "license": "SEE LICENSE IN LICENSE_1_0.txt",
     "engines": {
-        "vscode": "^1.5.0"
+        "vscode": "^1.9.1"
     },
     "galleryBanner": {
         "color": "#d6e685",


### PR DESCRIPTION
本拡張機能が依存しているvscodeのenginesを`"^1.9.1"`に修正します。

まっさらな状態から本リポジトリを`git clone`して`npm install`してビルドしようとしたら、下記`openTextDocument`のオーバーロードが見つからずにコンパイルできませんでした。
``` ts
export function openTextDocument(options?: { language: string; }): Thenable<TextDocument>;
```

上記の`openTextDocument`APIが定義されるvscodeのバージョンは
[ Visual Studio Code January 2017](https://code.visualstudio.com/updates/v1_9#_new-api-to-open-an-untitled-file-with-optional-language) (v1.9(リカバリー版はv1.9.1))
となっているようなので、`"^1.9.1"`としました。

修正により、`npm install`したときに`wandbox-vscode/node_modules/vscode/vscode.d.ts`内に`openTextDocument(options?: { language: string; })`が定義されるようになって、コンパイルできるようになったことを確認しました:ok_hand: