### PR TITLE
Fix Syntax Error at stdin-file-setting in Windows

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1127,8 +1127,8 @@ module WandboxVSCode
                         else
                         {
                             result = select.description
-                                .replace("\\","\\\\")
-                                .replace("\"","\\\"");
+                                .replace(/\\/g, "\\\\")
+                                .replace(/\"/g, "\\\"");
                         }
                     }
                     else


### PR DESCRIPTION
ファイルパス文字列のバックスラッシュとダブルクォートをエスケープする文字列置換処理をグローバルマッチするように修正します。

修正により、WindowsのVSCode上で
「`Wandbox: Set Options` -> `Select a file as stdin` -> [`何らかのファイル`]」と操作した時に、
下記のエラーが出ることがありましたが出なくなります。
```
🚫 SyntaxError: Unexpected token [XXXX] in JSON at position [nnn]
```
